### PR TITLE
Update render_engine_markdown importer

### DIFF
--- a/{{cookiecutter.project_slug}}/app.py
+++ b/{{cookiecutter.project_slug}}/app.py
@@ -9,7 +9,7 @@ from render_engine import (
     {% if not cookiecutter.skip_blog %}
     Blog
 )
-from render_engine.parsers.markdown import MarkdownPageParser
+from render_engine_markdown import MarkdownPageParser
 {% else %}
 )
 {% endif %}


### PR DESCRIPTION
This pull request updates the render_engine_markdown importer to fix an import error in the code. The previous code was importing from the wrong module, causing a runtime error. This PR corrects the import statement to import from the correct module.