### PR TITLE
[UPDATE] change pyproject.toml update

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,4 +1,4 @@
-[render-engine.cli]
+[tool.render-engine.cli]
 site = "app"
 module = "app"
 {% if not cookiecutter.skip_blog %}


### PR DESCRIPTION
> [!WARNING]
> This PR addresses the breaking changes from <https://github.com/render-engine/render-engine-cli/pull/12>
> Do not merge until 2025.7.1 is published

resolves #27

changes pyproject.toml from `[render.engine]` to `[tool.render.engine]`
